### PR TITLE
feat: auto detect Literate CoffeeScript if not specified explicitly

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,11 @@ var createCoffeePreprocessor = function(args, config, logger, helper) {
     // Clone the options because coffee.compile mutates them
     var opts = helper._.clone(options)
 
+    if (!('literate' in opts) &&
+        /\.(litcoffee|coffee\.md)$/.test(file.originalPath)) {
+      opts.literate = true
+    }
+
     try {
       result = coffee.compile(content, opts);
     } catch (e) {


### PR DESCRIPTION
If `literate` option is not specified treat `.litcoffee` and `.coffee.md` files
as **Literate CoffeeScript**.
