### PR TITLE
Depend on any 1.x version of coffee-script

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "author": "Vojta Jina <vojta.jina@gmail.com>",
   "dependencies": {
-    "coffee-script": "~1.7"
+    "coffee-script": "~1"
   },
   "peerDependencies": {
     "karma": ">=0.11.14"


### PR DESCRIPTION
The current package.json requires loading version 1.7.x of `coffee-script` which seems too specific. The pre-processor is only calling `.compile()` which should work for any 1.x version.

We're using `coffee-script@.1.8.0` in a project, and we don't want `karma-coffee-preprocessor` to pull in `coffee-script@1.7.1`.