### PR TITLE
README recommends to set preprocessor as plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ module.exports = function(config) {
     // make sure to include the .coffee files not the compiled .js files
     files: [
       '**/*.coffee'
+    ],
+
+    // the preprocessor should be included as plugin too
+    plugins: [
+      'karma-coffee-preprocessor'
     ]
   })
 }


### PR DESCRIPTION
If it is not included it shows a warning message :anger:  :
```
WARN [preprocess]: Can not load "coffee", it is not registered!
  Perhaps you are missing some plugin?
Fatal error: undefined is not a function
```