### PR TITLE
fix: warnings in chrome.

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ var createCoffeePreprocessor = function (args, config, logger, helper) {
       map.file = path.basename(file.path)
       file.sourceMap = map
       datauri = 'data:application/json;charset=utf-8;base64,' + new Buffer(JSON.stringify(map)).toString('base64')
-      done(null, result.js + '\n//@ sourceMappingURL=' + datauri + '\n')
+      done(null, result.js + '\n//# sourceMappingURL=' + datauri + '\n')
     } else {
       done(null, result.js || result)
     }


### PR DESCRIPTION
Fix '//@ sourceURL' and '//@ sourceMappingURL' are deprecated, please use '//# sourceURL=' and '//# sourceMappingURL=' in Chrome.