### PR TITLE
.travis.yml: update node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
 node_js:
-  - "iojs"
+  - "stable"
   - "0.12"
   - "0.10"
-  - "0.8"
 
 # Make sure we have new NPM.
 before_install:


### PR DESCRIPTION
This drops support for deprecated node versions and adds stable to always test on the latest stable release.