### PR TITLE
Use object-assign to clone options (Fix #36)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var coffee = require('coffee-script')
 var path = require('path')
+var assign = require('object-assign')
 
 var createCoffeePreprocessor = function (args, config, logger, helper) {
   config = config || {}
@@ -24,7 +25,7 @@ var createCoffeePreprocessor = function (args, config, logger, helper) {
     file.path = transformPath(file.originalPath)
 
     // Clone the options because coffee.compile mutates them
-    var opts = helper._.clone(options)
+    var opts = assign({}, options)
 
     try {
       result = coffee.compile(content, opts)

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   ],
   "author": "Vojta Jina <vojta.jina@gmail.com>",
   "dependencies": {
-    "coffee-script": "~1"
+    "coffee-script": "~1",
+    "object-assign": "^4.1.0"
   },
   "peerDependencies": {
     "karma": ">=0.11.14"


### PR DESCRIPTION
Karma 2 will no longer expose its copy of lodash, and is currently spewing out deprecation notices.